### PR TITLE
[P2P-174] 대댓글 관련 오류 fix(대댓글의 대댓글 작성 금지, 댓글 삭제 로직 오류) 

### DIFF
--- a/src/main/java/com/prgrms/p2p/domain/comment/dto/CourseCommentDto.java
+++ b/src/main/java/com/prgrms/p2p/domain/comment/dto/CourseCommentDto.java
@@ -25,7 +25,7 @@ public class CourseCommentDto {
   public static class UserDto {
 
     private Long id;
-    private String NickName;
+    private String nickname;
     private String profileImage;
   }
 }

--- a/src/main/java/com/prgrms/p2p/domain/comment/dto/PlaceCommentDto.java
+++ b/src/main/java/com/prgrms/p2p/domain/comment/dto/PlaceCommentDto.java
@@ -25,7 +25,7 @@ public class PlaceCommentDto {
   public static class UserDto {
 
     private Long id;
-    private String NickName;
+    private String nickname;
     private String profileImage;
   }
 }

--- a/src/main/java/com/prgrms/p2p/domain/comment/service/CourseCommentService.java
+++ b/src/main/java/com/prgrms/p2p/domain/comment/service/CourseCommentService.java
@@ -1,5 +1,6 @@
 package com.prgrms.p2p.domain.comment.service;
 
+import static com.prgrms.p2p.domain.comment.entity.Visibility.DELETED_INFORMATION;
 import static com.prgrms.p2p.domain.comment.util.CommentConverter.toCourseComment;
 
 import com.prgrms.p2p.domain.comment.dto.CreateCommentRequest;
@@ -7,6 +8,7 @@ import com.prgrms.p2p.domain.comment.dto.UpdateCommentRequest;
 import com.prgrms.p2p.domain.comment.entity.CourseComment;
 import com.prgrms.p2p.domain.comment.entity.Visibility;
 import com.prgrms.p2p.domain.comment.repository.CourseCommentRepository;
+import com.prgrms.p2p.domain.common.exception.BadRequestException;
 import com.prgrms.p2p.domain.common.exception.NotFoundException;
 import com.prgrms.p2p.domain.common.exception.UnAuthorizedException;
 import com.prgrms.p2p.domain.course.entity.Course;
@@ -32,9 +34,14 @@ public class CourseCommentService {
     Course course = getCourse(courseId);
 
     Long rootCommentId = createCommentReq.getRootCommentId();
-    validateAuth(
-        !Objects.isNull(rootCommentId) && !courseCommentRepository.existsById(rootCommentId),
-        "존재하지 않는 댓글에 하위 댓글을 작성할 수 없습니다.");
+
+    if (!Objects.isNull(rootCommentId)) {
+      CourseComment parentComment = courseCommentRepository.findById(rootCommentId)
+          .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글에 하위 댓글을 작성할 수 없습니다."));
+      if (!Objects.isNull(parentComment.getRootCommentId())) {
+        throw new BadRequestException("대댓글에 대댓글을 작성할 수 없습니다.");
+      }
+    }
 
     CourseComment courseComment = toCourseComment(createCommentReq, course, userId);
 
@@ -71,7 +78,7 @@ public class CourseCommentService {
       return;
     }
 
-    courseComment.changeVisibility(Visibility.DELETED_INFORMATION);
+    courseComment.changeVisibility(DELETED_INFORMATION);
   }
 
   private Course getCourse(Long courseId) {
@@ -87,10 +94,12 @@ public class CourseCommentService {
   }
 
   private void deleteParentComment(CourseComment courseComment) {
-    if (courseCommentRepository.findSubCommentCount(courseComment.getRootCommentId()) == 1) {
-      CourseComment parentComment = courseCommentRepository.findById(
-              courseComment.getRootCommentId())
-          .orElseThrow(() -> new NotFoundException("부모 댓글이 존재하지 않습니다."));
+    CourseComment parentComment
+        = courseCommentRepository.findById(courseComment.getRootCommentId())
+        .orElseThrow(() -> new NotFoundException("부모 댓글이 존재하지 않습니다."));
+
+    if (courseCommentRepository.findSubCommentCount(courseComment.getRootCommentId()) == 1
+        && parentComment.getVisibility().equals(DELETED_INFORMATION)) {
       parentComment.changeVisibility(Visibility.FALSE);
     }
   }

--- a/src/main/java/com/prgrms/p2p/domain/comment/service/CourseCommentService.java
+++ b/src/main/java/com/prgrms/p2p/domain/comment/service/CourseCommentService.java
@@ -1,12 +1,12 @@
 package com.prgrms.p2p.domain.comment.service;
 
+import static com.prgrms.p2p.domain.comment.entity.Visibility.*;
 import static com.prgrms.p2p.domain.comment.entity.Visibility.DELETED_INFORMATION;
 import static com.prgrms.p2p.domain.comment.util.CommentConverter.toCourseComment;
 
 import com.prgrms.p2p.domain.comment.dto.CreateCommentRequest;
 import com.prgrms.p2p.domain.comment.dto.UpdateCommentRequest;
 import com.prgrms.p2p.domain.comment.entity.CourseComment;
-import com.prgrms.p2p.domain.comment.entity.Visibility;
 import com.prgrms.p2p.domain.comment.repository.CourseCommentRepository;
 import com.prgrms.p2p.domain.common.exception.BadRequestException;
 import com.prgrms.p2p.domain.common.exception.NotFoundException;
@@ -69,12 +69,12 @@ public class CourseCommentService {
 
     if (!Objects.isNull(courseComment.getRootCommentId())) {
       deleteParentComment(courseComment);
-      courseComment.changeVisibility(Visibility.FALSE);
+      courseComment.changeVisibility(FALSE);
       return;
     }
 
-    if (courseCommentRepository.findSubCommentCount(courseComment.getId()) == 0) {
-      courseComment.changeVisibility(Visibility.FALSE);
+    if (courseCommentRepository.findSubCommentCount(courseComment.getId()).equals(0L)) {
+      courseComment.changeVisibility(FALSE);
       return;
     }
 
@@ -98,9 +98,9 @@ public class CourseCommentService {
         = courseCommentRepository.findById(courseComment.getRootCommentId())
         .orElseThrow(() -> new NotFoundException("부모 댓글이 존재하지 않습니다."));
 
-    if (courseCommentRepository.findSubCommentCount(courseComment.getRootCommentId()) == 1
+    if (courseCommentRepository.findSubCommentCount(courseComment.getRootCommentId()).equals(1L)
         && parentComment.getVisibility().equals(DELETED_INFORMATION)) {
-      parentComment.changeVisibility(Visibility.FALSE);
+      parentComment.changeVisibility(FALSE);
     }
   }
 }

--- a/src/test/java/com/prgrms/p2p/domain/comment/service/CourseCommentServiceTest.java
+++ b/src/test/java/com/prgrms/p2p/domain/comment/service/CourseCommentServiceTest.java
@@ -201,6 +201,26 @@ class CourseCommentServiceTest {
       assertThrows(RuntimeException.class,
           () -> courseCommentService.save(createCommentReq, courseId, userId));
     }
+
+    @Test
+    @DisplayName("실패: 대댓글에 대댓글을 작성하지 못합니다.")
+    public void failCreateSubSubComment() throws Exception {
+
+      //given
+      String comment = "이것은 실패할 대댓글입니다.";
+      Long rootCommentId = lastSubComment.getId();
+      Long userId = user.getId();
+      Long courseId = course.getId();
+
+      CreateCommentRequest createCommentReq = CreateCommentRequest.builder()
+          .comment(comment)
+          .rootCommentId(rootCommentId)
+          .build();
+
+      //then
+      assertThrows(RuntimeException.class,
+          () -> courseCommentService.save(createCommentReq, courseId, userId));
+    }
   }
 
   @Nested

--- a/src/test/java/com/prgrms/p2p/domain/comment/service/SearchCourseCommentServiceTest.java
+++ b/src/test/java/com/prgrms/p2p/domain/comment/service/SearchCourseCommentServiceTest.java
@@ -241,8 +241,8 @@ public class SearchCourseCommentServiceTest {
   }
 
   @Test
-  @DisplayName("대댓글을 삭제했을 때 부모의 댓글에 더이상 대댓글이 존재하지 않는다면(삭제한 대댓글이 마지막 대댓글이었다면) 부모 댓글도 더 이상 표시되지 않습니다.")
-  public void deleteLastSubComment() throws Exception {
+  @DisplayName("대댓글을 삭제했을 때 삭제된 부모의 댓글에 더이상 대댓글이 존재하지 않는다면(삭제한 대댓글이 마지막 대댓글이었다면) 부모 댓글도 더 이상 표시되지 않습니다.")
+  public void deleteLastSubCommentForDeletedParentComment() throws Exception {
 
     // given
     CourseCommentResponse responseBefore
@@ -265,6 +265,39 @@ public class SearchCourseCommentServiceTest {
         .filter(al -> al.getId().equals(parentComment4.getId()))
         .collect(Collectors.toList());
     assertThat(afterList.size()).isEqualTo(0);
+
+    // 결과 확인용
+    for (CourseCommentDto courseCommentResponse : responseAfter.getCourseComments()) {
+      System.out.println(
+          "" + courseCommentResponse.getComment() + " / 작성자 = " + courseCommentResponse.getUser()
+              .getNickName());
+    }
+  }
+
+  @Test
+  @DisplayName("마지막 대댓글을 삭제했을 때 부모댓글이 삭제 상태가 아니라면 부모 댓글도 더 이상 표시되지 않습니다.")
+  public void deleteLastSubCommentForVisibilityTrueComment() throws Exception {
+
+    // given
+    CourseCommentResponse responseBefore
+        = searchCourseCommentService.findCourseComment(course.getId());
+    List<CourseCommentDto> beforeList = responseBefore.getCourseComments().stream()
+        .filter(bl -> bl.getId().equals(parentComment4.getId()))
+        .collect(Collectors.toList());
+
+    assertThat(beforeList.size()).isEqualTo(1);
+
+    // when
+    courseCommentService.deleteCourseComment(lastSubComment.getId(), course.getId(), user.getId());
+
+    // then
+    CourseCommentResponse responseAfter
+        = searchCourseCommentService.findCourseComment(course.getId());
+
+    List<CourseCommentDto> afterList = responseAfter.getCourseComments().stream()
+        .filter(al -> al.getId().equals(parentComment4.getId()))
+        .collect(Collectors.toList());
+    assertThat(afterList.size()).isEqualTo(1);
 
     // 결과 확인용
     for (CourseCommentDto courseCommentResponse : responseAfter.getCourseComments()) {

--- a/src/test/java/com/prgrms/p2p/domain/comment/service/SearchCourseCommentServiceTest.java
+++ b/src/test/java/com/prgrms/p2p/domain/comment/service/SearchCourseCommentServiceTest.java
@@ -164,7 +164,7 @@ public class SearchCourseCommentServiceTest {
     for (CourseCommentDto courseCommentResponse : response.getCourseComments()) {
       System.out.println(
           "" + courseCommentResponse.getComment() + " / 작성자 = " + courseCommentResponse.getUser()
-              .getNickName());
+              .getNickname());
     }
   }
 
@@ -198,7 +198,7 @@ public class SearchCourseCommentServiceTest {
     for (CourseCommentDto courseCommentResponse : responseAfter.getCourseComments()) {
       System.out.println(
           "" + courseCommentResponse.getComment() + " / 작성자 = " + courseCommentResponse.getUser()
-              .getNickName());
+              .getNickname());
     }
   }
 
@@ -227,7 +227,7 @@ public class SearchCourseCommentServiceTest {
         .collect(Collectors.toList());
     assertThat(afterList.size()).isEqualTo(1);
     assertThat(afterList.get(0).getComment()).isEqualTo("삭제된 댓글입니다.");
-    assertThat(afterList.get(0).getUser().getNickName()).isNull();
+    assertThat(afterList.get(0).getUser().getNickname()).isNull();
     assertThat(afterList.get(0).getUser().getProfileImage()).isNull();
     assertThat(afterList.get(0).getCreatedAt()).isNull();
     assertThat(afterList.get(0).getUpdatedAt()).isNull();
@@ -236,7 +236,7 @@ public class SearchCourseCommentServiceTest {
     for (CourseCommentDto courseCommentResponse : responseAfter.getCourseComments()) {
       System.out.println(
           "" + courseCommentResponse.getComment() + " / 작성자 = " + courseCommentResponse.getUser()
-              .getNickName());
+              .getNickname());
     }
   }
 
@@ -270,7 +270,7 @@ public class SearchCourseCommentServiceTest {
     for (CourseCommentDto courseCommentResponse : responseAfter.getCourseComments()) {
       System.out.println(
           "" + courseCommentResponse.getComment() + " / 작성자 = " + courseCommentResponse.getUser()
-              .getNickName());
+              .getNickname());
     }
   }
 
@@ -303,7 +303,7 @@ public class SearchCourseCommentServiceTest {
     for (CourseCommentDto courseCommentResponse : responseAfter.getCourseComments()) {
       System.out.println(
           "" + courseCommentResponse.getComment() + " / 작성자 = " + courseCommentResponse.getUser()
-              .getNickName());
+              .getNickname());
     }
   }
 
@@ -338,7 +338,7 @@ public class SearchCourseCommentServiceTest {
     for (CourseCommentDto courseCommentResponse : responseAfter.getCourseComments()) {
       System.out.println(
           "" + courseCommentResponse.getComment() + " / 작성자 = " + courseCommentResponse.getUser()
-              .getNickName());
+              .getNickname());
     }
   }
 }


### PR DESCRIPTION
💙 좋은 코드 리뷰는 친절한 PR로 부터 나옵니다! 모두들 꼼꼼히 작성해주세요. 💙

## 업무 배경

> 업무 이유, 목적, 이슈 등 업무의 배경을 간단하게 1줄 요약 합니다.

- 마지막 대댓글을 삭제하면 댓글도 같이 삭제되는 점을 수정했습니다. (부모 댓글의 상태가 deleted_information)일때만 동작하도록
- 대댓글에 대댓글이 작성되지 못하도록 했습니다.

## 개발 내용

> 수정 or 추가, 개발된 내용에 대해서 1줄로 간단히 작성합니다.

- 여기에 내용 기재

## 집중적인 코드리뷰

> 좀 더 상세하게 리뷰 받고 싶은 부분을 기재해주세요.

- 여기에 내용 기재

## 리마인더

- 본인의 로컬에서 정상 동작하는지 확인해주세요.
- 최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
- API가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
- Conflict가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
- commit 메시지 제대로 작성해주세요.
