### PR TITLE
[P2P-158] 코스 댓글 수정 / 삭제 기능 버그 fix

### DIFF
--- a/src/main/java/com/prgrms/p2p/domain/comment/service/CourseCommentService.java
+++ b/src/main/java/com/prgrms/p2p/domain/comment/service/CourseCommentService.java
@@ -52,9 +52,12 @@ public class CourseCommentService {
   public Long updateCourseComment(UpdateCommentRequest updateReq, Long courseCommentId,
       Long courseId, Long userId) {
 
-    notFoundMessage(!courseRepository.existsById(courseId), "게시글이 존재하지 않습니다.");
+    Course course = getCourse(courseId);
+
     CourseComment courseComment = courseCommentRepository.findById(courseCommentId)
         .orElseThrow(() -> new NotFoundException("수정 불가: 존재하지 않은 댓글입니다"));
+
+    notFoundMessage(!courseComment.getCourse().equals(course), "해당 코스에 존재하지 않는 댓글입니다.");
 
     validateAuth(!courseComment.getUserId().equals(userId), "댓글의 수정 권한이 없습니다.");
 
@@ -64,9 +67,12 @@ public class CourseCommentService {
 
   public void deleteCourseComment(Long courseCommentId, Long courseId, Long userId) {
 
-    notFoundMessage(!courseRepository.existsById(courseId), "게시글이 존재하지 않습니다.");
+    Course course = getCourse(courseId);
+
     CourseComment courseComment = courseCommentRepository.findById(courseCommentId)
         .orElseThrow(() -> new NotFoundException("삭제 불가: 존재하지 않은 댓글입니다"));
+
+    notFoundMessage(!courseComment.getCourse().equals(course), "해당 코스에 존재하지 않는 댓글입니다.");
 
     if (!courseComment.getVisibility().equals(TRUE)) {
       throw new BadRequestException("이미 삭제된 댓글은 삭제할 수 없습니다.");


### PR DESCRIPTION
…어도 수정, 삭제가 정상적으로 이루어짐) 수정

💙 좋은 코드 리뷰는 친절한 PR로 부터 나옵니다! 모두들 꼼꼼히 작성해주세요. 💙

## 업무 배경

> 업무 이유, 목적, 이슈 등 업무의 배경을 간단하게 1줄 요약 합니다.

- http://localhost:8080/api/v1/courses/594/comments/621
- 코스와 댓글이 둘다 존재하기만 한다면 댓글(621)이 코스(594)에 작성되지 않았음에도 불구하고 정상적으로 수정, 삭제가 이루어 지는 것을 막았습니다.

## 개발 내용

> 수정 or 추가, 개발된 내용에 대해서 1줄로 간단히 작성합니다.

- 여기에 내용 기재

## 집중적인 코드리뷰

> 좀 더 상세하게 리뷰 받고 싶은 부분을 기재해주세요.

- 여기에 내용 기재

## 리마인더

- 본인의 로컬에서 정상 동작하는지 확인해주세요.
- 최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
- API가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
- Conflict가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
- commit 메시지 제대로 작성해주세요.
